### PR TITLE
WIP: try to reintroduce sourcelink support

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -116,7 +116,7 @@ Target "Build" <| fun () ->
  else
     // BoTH flavours of FSharp.Data.DesignTime.dll (net45 and netstandard2.0) must be built _before_ building FSharp.Data
     let build proj = 
-        DotNetCli.RunCommand (fun p -> { p with ToolPath = getSdkPath() }) (sprintf "build -c Release \"%s\" /p:SourceLinkCreate=true /p:SourceLinkServerType=GitHub" proj)
+        DotNetCli.RunCommand (fun p -> { p with ToolPath = getSdkPath() }) (sprintf "build -c Release \"%s\" /p:SourceLinkCreate=true" proj)
     build "src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj"
     build "src/FSharp.Data/FSharp.Data.fsproj"
 

--- a/build.fsx
+++ b/build.fsx
@@ -111,12 +111,22 @@ Target "Build" <| fun () ->
  if useMsBuildToolchain then
     DotNetCli.Restore  (fun p -> { p with Project = "src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj"; ToolPath =  getSdkPath() })
     DotNetCli.Restore (fun p -> { p with Project = "src/FSharp.Data/FSharp.Data.fsproj"; ToolPath =  getSdkPath() })
-    MSBuildRelease null "Build" ["src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj"] |> Log "FSharp.Data.DesignTime-Output: "
-    MSBuildRelease null "Build" ["src/FSharp.Data/FSharp.Data.fsproj"] |> Log "FSharp.Data-Output: "
+    MSBuildReleaseExt null ["SourceLinkCreate", "true"] "Build" ["src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj"] |> Log "FSharp.Data.DesignTime-Output: "
+    MSBuildReleaseExt null ["SourceLinkCreate", "true"] "Build" ["src/FSharp.Data/FSharp.Data.fsproj"] |> Log "FSharp.Data-Output: "
  else
     // BoTH flavours of FSharp.Data.DesignTime.dll (net45 and netstandard2.0) must be built _before_ building FSharp.Data
-    DotNetCli.Build  (fun p -> { p with Configuration = "Release"; Project = "src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj"; ToolPath =  getSdkPath() })
-    DotNetCli.Build (fun p -> { p with Configuration = "Release"; Project = "src/FSharp.Data/FSharp.Data.fsproj"; ToolPath =  getSdkPath() })
+    let build proj = 
+        DotNetCli.RunCommand (fun p -> { p with ToolPath = getSdkPath() }) (sprintf "build -c Release \"%s\" /p:SourceLinkCreate=true /p:SourceLinkServerType=GitHub" proj)
+    build "src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj"
+    build "src/FSharp.Data/FSharp.Data.fsproj"
+
+    let testSourcelink proj = 
+        let basePath = Path.GetFileNameWithoutExtension proj
+        let pdb = sprintf "bin/Release/netstandard2.0/%s.pdb" basePath
+        DotNetCli.RunCommand (fun p -> { p with ToolPath = getSdkPath(); WorkingDir = Path.GetDirectoryName proj }) (sprintf "sourcelink test %s" pdb)
+    
+    testSourcelink "src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj"
+    testSourcelink "src/FSharp.Data/FSharp.Data.fsproj"
 
 Target "BuildTests" <| fun () ->
   for testProj in testProjs do 

--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -5,6 +5,7 @@
     <DefineConstants>NO_GENERATIVE</DefineConstants>
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\UriUtils.fs" />
@@ -65,5 +66,9 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.0.0.1" Condition="'$(TargetFramework)' == 'net45'" />
     <PackageReference Include="FSharp.Core" Version="4.2.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <PackageReference Include="SourceLink.Test" Version="2.8.0" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.0" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 </Project>

--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -5,7 +5,6 @@
     <DefineConstants>NO_GENERATIVE</DefineConstants>
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\UriUtils.fs" />
@@ -67,7 +66,7 @@
     <PackageReference Include="FSharp.Core" Version="4.0.0.1" Condition="'$(TargetFramework)' == 'net45'" />
     <PackageReference Include="FSharp.Core" Version="4.2.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Test" Version="2.8.0" PrivateAssets="all" />
+    <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.8.0" PrivateAssets="all" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 </Project>

--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -68,7 +68,6 @@
     <PackageReference Include="FSharp.Core" Version="4.2.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Test" Version="2.8.0" PrivateAssets="all" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.0" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 </Project>

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>netstandard2.0; net45</TargetFrameworks>
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\UriUtils.fs" />
@@ -42,7 +43,6 @@
     <PackageReference Include="FSharp.Core" Version="4.2.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
     <PackageReference Include="SourceLink.Test" Version="2.8.0" PrivateAssets="all" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.0" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -40,6 +40,10 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.0.0.1" Condition="'$(TargetFramework)' == 'net45'" />
     <PackageReference Include="FSharp.Core" Version="4.2.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
+    <PackageReference Include="SourceLink.Test" Version="2.8.0" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.0" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>netstandard2.0; net45</TargetFrameworks>
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\UriUtils.fs" />
@@ -42,7 +41,7 @@
     <PackageReference Include="FSharp.Core" Version="4.0.0.1" Condition="'$(TargetFramework)' == 'net45'" />
     <PackageReference Include="FSharp.Core" Version="4.2.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
-    <PackageReference Include="SourceLink.Test" Version="2.8.0" PrivateAssets="all" />
+    <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.8.0" PrivateAssets="all" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 


### PR DESCRIPTION
With the code below I get the following on my machine:
```
/Users/chethusk/.local/share/dotnetcore/dotnet build -c Release "src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj" /p:SourceLinkCreate=true /p:SourceLinkServerType=GitHub
Microsoft (R) Build Engine version 15.6.81.24225 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj...
  Restore completed in 105.87 ms for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj.
  Restore completed in 105.87 ms for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj.
  Generating MSBuild file /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/obj/FSharp.Data.DesignTime.fsproj.nuget.g.props.
  Generating MSBuild file /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/obj/FSharp.Data.DesignTime.fsproj.nuget.g.targets.
  Restore completed in 1.03 sec for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj.
  FSharp.Data.DesignTime -> /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/bin/Release/net45/FSharp.Data.DesignTime.dll
  FSharp.Data.DesignTime -> /Users/chethusk/oss/FSharp.Data/src/FSharp.Data.DesignTime/bin/Release/netstandard2.0/FSharp.Data.DesignTime.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:27.67
/Users/chethusk/.local/share/dotnetcore/dotnet build -c Release "src/FSharp.Data/FSharp.Data.fsproj" /p:SourceLinkCreate=true /p:SourceLinkServerType=GitHub
Microsoft (R) Build Engine version 15.6.81.24225 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/FSharp.Data.fsproj...
  Restore completed in 116.51 ms for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/FSharp.Data.fsproj.
  Restore completed in 116.46 ms for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/FSharp.Data.fsproj.
  Generating MSBuild file /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/obj/FSharp.Data.fsproj.nuget.g.props.
  Generating MSBuild file /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/obj/FSharp.Data.fsproj.nuget.g.targets.
  Restore completed in 611.65 ms for /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/FSharp.Data.fsproj.
  FSharp.Data -> /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/bin/Release/net45/FSharp.Data.dll
  FSharp.Data -> /Users/chethusk/oss/FSharp.Data/src/FSharp.Data/bin/Release/netstandard2.0/FSharp.Data.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:15.05
/Users/chethusk/.local/share/dotnetcore/dotnet sourcelink test bin/Release/netstandard2.0/FSharp.Data.DesignTime.pdb
2 Documents with errors:
15292235b69b161c0f7771a81a74b525 md5 fsharp /Users/chethusk/oss/FSharp.Data/paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/ProvidedTypes.fs
https://raw.githubusercontent.com/baronfel/FSharp.Data/6b64a9e42796afd32e40088c1d5112a7296d72d4/paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/ProvidedTypes.fs
error: url failed NotFound: Not Found
3e848a3af18e699d5fa0f7267fc06711 md5 fsharp /Users/chethusk/oss/FSharp.Data/paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/ProvidedTypesTesting.fs
https://raw.githubusercontent.com/baronfel/FSharp.Data/6b64a9e42796afd32e40088c1d5112a7296d72d4/paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/ProvidedTypesTesting.fs
error: url failed NotFound: Not Found
sourcelink test failed
Running build failed.
Error:
System.Exception: dotnet command failed on sourcelink test bin/Release/netstandard2.0/FSharp.Data.DesignTime.pdb
  at Fake.DotNetCli+RunCommand@78-3.Invoke (System.String message) [0x00000] in <5a8d2d45ccf1c534a7450383452d8d5a>:0
  at Microsoft.FSharp.Core.PrintfImpl+StringPrintfEnv`1[TResult].Finalize () [0x00012] in <5893d081904cf4daa745038381d09358>:0
  at Microsoft.FSharp.Core.PrintfImpl+Final1@224[TState,TResidue,TResult,A].Invoke (Microsoft.FSharp.Core.FSharpFunc`2[T,TResult] env, A a) [0x00038] in <5893d081904cf4daa745038381d09358>:0
  at Microsoft.FSharp.Core.OptimizedClosures+Invoke@3253[T2,TResult,T1].Invoke (T2 u) [0x00001] in <5893d081904cf4daa745038381d09358>:0
  at Fake.DotNetCli.RunCommand (Microsoft.FSharp.Core.FSharpFunc`2[T,TResult] setCommandParams, System.String args) [0x00054] in <5a8d2d45ccf1c534a7450383452d8d5a>:0
  at FSI_0005.Build+testSourcelink@124.Invoke (System.String proj) [0x00055] in <676c1e87020c4a9a8d5d4efaefc66762>:0
  at FSI_0005.Build+clo@110-10.Invoke (Microsoft.FSharp.Core.Unit unitVar0) [0x0012b] in <676c1e87020c4a9a8d5d4efaefc66762>:0
  at Fake.TargetHelper+targetFromTemplate@209-1[a].Invoke (Microsoft.FSharp.Core.Unit unitVar0) [0x00000] in <5a8d2d45ccf1c534a7450383452d8d5a>:0
  at Fake.TargetHelper.runSingleTarget (Fake.TargetHelper+TargetTemplate`1[a] target) [0x00049] in <5a8d2d45ccf1c534a7450383452d8d5a>:0
```